### PR TITLE
Move Node title logic to the Page class

### DIFF
--- a/src/Components/HistoryPanel.ts
+++ b/src/Components/HistoryPanel.ts
@@ -24,6 +24,7 @@ export class HistoryPanel {
       cls: "excalibrain-history-container"
     })
     const nh = this.plugin.settings.navigationHistory;
+
     for(let i=nh.length-1;i>=0;i--) {
       if(i !== nh.length-1) {
         container.createDiv({
@@ -46,7 +47,7 @@ export class HistoryPanel {
              };
 
       if(page.file) {
-        displayName = style.prefix + page.name;
+        displayName = style.prefix + page.getTitle();
         link = label = page.path;
       } else {
 

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -53,16 +53,7 @@ export class Node {
       };
     }
     this.friendGateOnLeft = x.friendGateOnLeft;
-    this.title = this.getTitle();
-  }
-
-  private getTitle(): string {
-    const aliases = (this.page.file && this.settings.renderAlias)
-      ? (this.page.dvPage?.file?.aliases?.values??[])
-      : [];
-    return aliases.length > 0 
-      ? aliases[0] 
-      : this.page.name
+    this.title = this.page.getTitle();
   }
 
 

--- a/src/graph/Page.ts
+++ b/src/graph/Page.ts
@@ -86,6 +86,15 @@ export class Page {
     this.settings = plugin.settings;
   }
 
+  public getTitle(): string {
+    const aliases = (this.file && this.plugin.settings.renderAlias)
+      ? (this.dvPage?.file?.aliases?.values??[])
+      : [];
+    return aliases.length > 0 
+      ? aliases[0] 
+      : this.name
+  }
+
   private getNeighbours(): [string, Relation][] {
     const { showVirtualNodes, showAttachments, showFolderNodes, showTagNodes, showPageNodes } = this.settings
     return Array.from(this.neighbours)


### PR DESCRIPTION
Now Node and HistoryPanel classes can both respect the renderAlias setting.

This is the first way I thought of how to do it. I didn't have a lot of time to look into the architecture of the plugin. If this goes against any conventions or patterns you're using, let me know and I'll accommodate.

Implements #42 