### PR TITLE
Preparing for better 'compact view'

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
 	"description": "A clean, intuitive and editable graph view for Obsidian",
 	"author": "Zsolt Viczian",
 	"authorUrl": "https://zsolt.blog",
+	"fundingUrl": "https://ko-fi.com/zsolt",
 	"isDesktopOnly": false
 }

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -364,6 +364,7 @@ export class Scene {
       if(n.page.path === this.ea.targetView.file.path) {
         return; 
       }
+      n.page.maxLabelLength = x.layout.spec.maxLabelLength;
       const node = new Node({
         ea: this.ea,
         page: n.page,

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -308,7 +308,11 @@ export class Scene {
     api.setMobileModeAllowed(false); //disable mobile view https://github.com/zsviczian/excalibrain/issues/9
     ea.style.fontFamily = style.fontFamily;
     ea.style.fontSize = style.fontSize;
-    this.textSize = ea.measureText("m".repeat(style.maxLabelLength));
+    const textSixe4x = ea.measureText("mi3l".repeat(style.maxLabelLength));
+    this.textSize = {
+      width: textSixe4x.width * 0.25,
+      height: textSixe4x.height
+    }
     this.nodeWidth = this.textSize.width + 2 * style.padding;
     if(this.plugin.settings.compactView) {
       this.nodeWidth = this.nodeWidth * 0.6;
@@ -524,6 +528,7 @@ export class Scene {
       rowHeight: isCenterEmbedded
         ? centerEmbedHeight
         : this.nodeHeight,
+        maxLabelLength: baseStyle.maxLabelLength
     });
     this.layouts.push(lCenter);
 
@@ -538,7 +543,8 @@ export class Scene {
       bottom: null,
       columns: childrenCols,
       columnWidth: this.nodeWidth,
-      rowHeight: this.nodeHeight
+      rowHeight: this.nodeHeight,
+      maxLabelLength: baseStyle.maxLabelLength
     });
     this.layouts.push(lChildren);
   
@@ -560,7 +566,8 @@ export class Scene {
       bottom: null,
       columns: 1,
       columnWidth: this.nodeWidth,
-      rowHeight: this.nodeHeight
+      rowHeight: this.nodeHeight,
+      maxLabelLength: baseStyle.maxLabelLength
     });
     this.layouts.push(lFriends);
 
@@ -573,7 +580,8 @@ export class Scene {
       bottom: null,
       columns: 1,
       columnWidth: this.nodeWidth,
-      rowHeight: this.nodeHeight
+      rowHeight: this.nodeHeight,
+      maxLabelLength: baseStyle.maxLabelLength
     });
     this.layouts.push(lNextFriends);
 
@@ -584,7 +592,8 @@ export class Scene {
       bottom: -2 * this.nodeHeight,
       columns: parentCols, // 3,
       columnWidth: this.nodeWidth,
-      rowHeight: this.nodeHeight
+      rowHeight: this.nodeHeight,
+      maxLabelLength: baseStyle.maxLabelLength
     });
     this.layouts.push(lParents);
     
@@ -605,9 +614,11 @@ export class Scene {
       columns: siblingsCols, 
       columnWidth: siblingsNodeWidth,
       rowHeight: siblingsNodeHeight,
+      maxLabelLength: baseStyle.maxLabelLength
     })
     this.layouts.push(lSiblings);
 
+    centralPage.maxLabelLength = baseStyle.maxLabelLength; 
     this.rootNode = new Node({
       ea,
       page: centralPage,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -130,6 +130,7 @@ export type LayoutSpecification = {
   bottom: number;
   rowHeight: number;
   columnWidth: number;
+  maxLabelLength: number;
 }
 
 export type Dimensions = {width:number, height:number};

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -77,8 +77,10 @@ export class Node {
 
   private displayText(): string {
     const label = (this.style.prefix??"") + this.title;
-    return label.length > this.style.maxLabelLength
-      ? label.substring(0,this.style.maxLabelLength-1) + "..."
+    const segmentedLength = [...new Intl.Segmenter().segment(label)].length; //'Unicode-proof' https://stackoverflow.com/questions/54369513/how-to-count-the-correct-length-of-a-string-with-emojis-in-javascript
+    const lengthCorrection = label.length-segmentedLength;
+    return segmentedLength > this.page.maxLabelLength 
+      ? label.substring(0,this.page.maxLabelLength+lengthCorrection-3) + "..."
       : label;
   }
 

--- a/src/graph/Page.ts
+++ b/src/graph/Page.ts
@@ -55,7 +55,8 @@ export class Page {
   public dvPage: Record<string, Literal>;
   public primaryStyleTag: string;
   public dvIndexReady: boolean = false;
-  
+  public maxLabelLength: number;
+
   constructor(
     private pages: Pages,
     public path:string,


### PR DESCRIPTION
Taking changes in small steps with main goal: better 'compact view' for small displays: 
No visible render changes, just preparation for later: 

- added property 'maxLabelLength' to: page.ts (public property) and  types.ts (LayoutSpecification).
- displayText() in node.ts reads page.maxLabelLength instead of style.maxLabelLength.
- measuring exact text length by using Intl.Segmenter()both in node.ts and scene.ts  ref.  'Unicode-proof' https://stackoverflow.com/questions/54369513/how-to-count-the-correct-length-of-a-string-with-emojis-in-javascript.