### PR TITLE
node length malshortening - fixed

### DIFF
--- a/src/Components/ToggleButton.ts
+++ b/src/Components/ToggleButton.ts
@@ -7,7 +7,7 @@ export class ToggleButton {
   private getVal: ()=>boolean;
   private isEnabled: ()=>boolean;
 
-  constructor({ plugin, getVal, setVal, isEnabled, wrapper, options, updateIndex} : {
+  constructor({ plugin, getVal, setVal, isEnabled, wrapper, options, updateIndex, shouldRerenderOnToggle} : {
     plugin: ExcaliBrain,
     getVal: ()=>boolean,
     setVal: (val:boolean)=>boolean,
@@ -18,8 +18,12 @@ export class ToggleButton {
       icon?: string | {on: string, off: string},
       tooltip: string
     },
-    updateIndex: boolean
+    updateIndex: boolean,
+    shouldRerenderOnToggle?: boolean,
   }) {
+    if(typeof shouldRerenderOnToggle === "undefined") {
+      shouldRerenderOnToggle = true;
+    }
     this.getVal = getVal;
     this.isEnabled = isEnabled;
     this.button = wrapper.createEl("button", {
@@ -45,7 +49,7 @@ export class ToggleButton {
       if(shouldSaveSettings) plugin.saveSettings();
       this.updateButton();
       if(options.icon) this.button.innerHTML = getIcon(getVal());
-      plugin.scene?.reRender(updateIndex);
+      if(shouldRerenderOnToggle) plugin.scene?.reRender(updateIndex);
     }
   }
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -546,7 +546,7 @@ export class Scene {
 
     this.nodeHeight = compactFactor * (baseChar.height + 2 * basestyle.padding);
     const padding = 6 * basestyle.padding;
-    const prefixLength = rootNode.prefix.length;
+    const prefixLength = Math.max(rootNode.prefix.length,1);
 
     // container
     const container = ea.targetView.containerEl;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -536,6 +536,7 @@ export class Scene {
 
     this.nodeHeight = compactFactor * (baseChar.height + 2 * basestyle.padding);
     const padding = 6 * basestyle.padding;
+    const prefixLength = 1;
 
     // container
     const container = ea.targetView.containerEl;
@@ -584,33 +585,32 @@ export class Scene {
     const rootTitle = centralPage.getTitle();
     const rootNode = ea.measureText(rootTitle.repeat(1));
     const actualRootLength = [...new Intl.Segmenter().segment(rootTitle)].length;
-    const rootNodeLength = Math.min(actualRootLength, style.maxLabelLength);
+    const rootNodeLength = Math.min(actualRootLength + prefixLength, style.maxLabelLength);
     const rootWidth = rootNode.width + 2 * style.padding;
-
     const heightInCenter = isCenterEmbedded
       ? centerEmbedHeight + 2 * this.nodeHeight
       : 4 *this.nodeHeight;
     
     //parents
-    const parentLabelLength = Math.min(this.longestTitle(parents), correctedMinLabelLength);
+    const parentLabelLength = Math.min(this.longestTitle(parents) + prefixLength, correctedMinLabelLength);
     const parentWidth = horizontalFactor * (parentLabelLength * baseChar.width + padding);
 
     //children
-    const childLength = Math.min(this.longestTitle(children,20), correctedMinLabelLength);
+    const childLength = Math.min(this.longestTitle(children,20) + prefixLength, correctedMinLabelLength);
     const childWidth = horizontalFactor * (childLength * baseChar.width + padding);
 
     // friends
-    const friendLength = Math.min(this.longestTitle(friends),correctedMinLabelLength);
+    const friendLength = Math.min(this.longestTitle(friends) + prefixLength,correctedMinLabelLength);
     const friendWidth = horizontalFactor * (friendLength * baseChar.width + padding);
 
     // nextfriends
-    const nextFriendLength = Math.min(this.longestTitle(nextFriends), correctedMinLabelLength);
+    const nextFriendLength = Math.min(this.longestTitle(nextFriends) + prefixLength, correctedMinLabelLength);
     const nextFriendWidth = horizontalFactor * (nextFriendLength * baseChar.width + padding);
 
     //siblings
     const siblingsStyle = settings.siblingNodeStyle;
     const siblingsPadding = siblingsStyle.padding??settings.baseNodeStyle.padding;
-    const siblingsLabelLength = Math.min(this.longestTitle(siblings,20), correctedMinLabelLength);
+    const siblingsLabelLength = Math.min(this.longestTitle(siblings,20) + prefixLength, correctedMinLabelLength);
     ea.style.fontFamily = siblingsStyle.fontFamily;
     ea.style.fontSize = siblingsStyle.fontSize;
     const siblingsTextSize = ea.measureText("m".repeat(siblingsLabelLength+3));

--- a/src/excalibrain-main.ts
+++ b/src/excalibrain-main.ts
@@ -28,6 +28,7 @@ declare module "obsidian" {
   }
   interface WorkspaceLeaf {
     id: string;
+    activeTime: number;
   }
 }
 
@@ -634,7 +635,7 @@ export default class ExcaliBrain extends Plugin {
         return false;
       }
 
-      const centralLeaf = this.scene.getCentralLeaf();
+      const centralLeaf = this.scene.centralLeaf;
       //handle click on link to existing file
       if(!page.isFolder && !page.isTag && !page.isURL) {
         //if the leaf attached to ExcaliBrain already has the new file open, render the associated graph

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -74,9 +74,12 @@ export class Node {
     this.title = this.page.getTitle();
   }
 
+  get prefix(): string {
+    return(this.style.prefix??"");
+  }
 
   private displayText(): string {
-    const label = (this.style.prefix??"") + this.title;
+    const label = this.prefix + this.title;
     const segmentedLength = [...new Intl.Segmenter().segment(label)].length; //'Unicode-proof' https://stackoverflow.com/questions/54369513/how-to-count-the-correct-length-of-a-string-with-emojis-in-javascript
     const lengthCorrection = label.length-segmentedLength;
     return segmentedLength > this.page.maxLabelLength 


### PR DESCRIPTION
A prefix buffer of +1  had to be added to minimal found nodelength for all children, parents etc. in case there is later added a prefix icon.
<img width="526" alt="Skjermbilde 2023-08-02 kl  18 30 41" src="https://github.com/zsviczian/excalibrain/assets/125663371/9b7b3787-9292-47f9-97f5-70c9f57d6b3b">
<img width="498" alt="Skjermbilde 2023-08-02 kl  18 30 22" src="https://github.com/zsviczian/excalibrain/assets/125663371/4d1e4d44-dfb9-46e6-97ff-908010a17109">
