### PR TITLE
CarlB01 - fix unexpected node shortening and node wrap

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -693,8 +693,6 @@ export class Scene {
    * @returns 
    */
   private async render(retainCentralNode:boolean = false) {
-    console.time('render ADHD');
-
     if(this.historyPanel) {
       this.historyPanel.rerender()
     }
@@ -904,9 +902,7 @@ export class Scene {
       });
     }
 
-
-    console.timeEnd('render ADHD');
-
+    
     //-------------------------------------------------------
     // Generate links for all displayed nodes
     const addLinks = (nodeA: Node, neighbours:Neighbour[],role: Role) => {

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -150,6 +150,21 @@ export class Scene {
     return Math.max(...lengths);
   }
 
+  /** iterates through a neighbour stack and returns the longest title length (emoji-safe) found.
+   * @param Neighbour[]
+   * @returns number
+   * @description: Implements Intl.Segmenter()
+  */ 
+  private longestTitleWithSegmenter(neighbours: Neighbour[], checkMax:number=20): number {
+    const lengths:number[] = [0];
+    for (let index = 0; (index<neighbours.length) && (index<=checkMax); index++) {
+      const title = neighbours[index].page.getTitle();
+      const segmentedLength = [...new Intl.Segmenter().segment(title)].length;
+      lengths.push(segmentedLength);
+    }
+    return Math.max(...lengths);
+  }
+
 
   /**
    * Renders the ExcaliBrain graph for the file provided by its path
@@ -318,9 +333,6 @@ export class Scene {
     ea.style.fontSize = style.fontSize;
     this.textSize = ea.measureText("m".repeat(style.maxLabelLength));
     this.nodeWidth = this.textSize.width + 2 * style.padding;
-    if(this.plugin.settings.compactView) {
-      this.nodeWidth = this.nodeWidth * 0.6;
-    }
     this.nodeHeight = 2 * (this.textSize.height + 2 * style.padding);
 
     const frame1 = () => {
@@ -546,8 +558,8 @@ export class Scene {
 
     this.nodeHeight = compactFactor * (baseChar.height + 2 * basestyle.padding);
     const padding = 6 * basestyle.padding;
-    const prefixLength = Math.max(rootNode.prefix.length,1);
-
+    const prefixLength = Math.max(rootNode.prefix.length,2);
+    
     // container
     const container = ea.targetView.containerEl;
     const h = container.innerHeight-150;
@@ -681,6 +693,8 @@ export class Scene {
    * @returns 
    */
   private async render(retainCentralNode:boolean = false) {
+    console.time('render ADHD');
+
     if(this.historyPanel) {
       this.historyPanel.rerender()
     }
@@ -889,6 +903,9 @@ export class Scene {
         friendGateOnLeft: true
       });
     }
+
+
+    console.timeEnd('render ADHD');
 
     //-------------------------------------------------------
     // Generate links for all displayed nodes
@@ -1187,7 +1204,7 @@ export class Scene {
     this.toolsPanel?.terminate();
     this.toolsPanel = undefined;
     this.historyPanel?.terminate();
-    this.historyPanel = undefined;
+    this.historyPanel = undefined;  
     this.ea.targetView = undefined;
     this.leaf = undefined;
     this.centralLeaf = undefined;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -150,22 +150,6 @@ export class Scene {
     return Math.max(...lengths);
   }
 
-  /** iterates through a neighbour stack and returns the longest title length (emoji-safe) found.
-   * @param Neighbour[]
-   * @returns number
-   * @description: Implements Intl.Segmenter()
-  */ 
-  private longestTitleWithSegmenter(neighbours: Neighbour[], checkMax:number=20): number {
-    const lengths:number[] = [0];
-    for (let index = 0; (index<neighbours.length) && (index<=checkMax); index++) {
-      const title = neighbours[index].page.getTitle();
-      const segmentedLength = [...new Intl.Segmenter().segment(title)].length;
-      lengths.push(segmentedLength);
-    }
-    return Math.max(...lengths);
-  }
-
-
   /**
    * Renders the ExcaliBrain graph for the file provided by its path
    * @param path 

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -79,11 +79,11 @@ export class Node {
   }
 
   private displayText(): string {
-    const label = this.prefix + this.title;
-    const segmentedLength = [...new Intl.Segmenter().segment(label)].length; //'Unicode-proof' https://stackoverflow.com/questions/54369513/how-to-count-the-correct-length-of-a-string-with-emojis-in-javascript
-    const lengthCorrection = label.length-segmentedLength;
-    return segmentedLength > this.page.maxLabelLength 
-      ? label.substring(0,this.page.maxLabelLength+lengthCorrection-3) + "..."
+    const label = (this.style.prefix??"") + this.title;    
+    const segmentedLabel = new Intl.Segmenter().segment(label); // a tough problem string const str = "❤️😊👨‍👩‍👦"; developed from hint here: https://stackoverflow.com/questions/73145508/how-to-truncate-utf8-string-in-javascript-without-breaking-multibyte-characters/73145642#73145642
+    const segArr = Array.from(segmentedLabel, ({segment}) => segment);
+    return segArr.length > this.page.maxLabelLength
+      ? segArr.slice(0,this.page.maxLabelLength-3).join('') + "..."
       : label;
   }
 
@@ -177,7 +177,7 @@ export class Node {
       this.center.y - labelSize.height / 2,
       label,
       {
-        wrapAt: this.style.maxLabelLength+50,
+        wrapAt: this.page.maxLabelLength+50,
         textAlign: "center",
         box: true,
         boxPadding: this.style.padding,


### PR DESCRIPTION
- segmenter length (node.ts) improved.
-plus  a minimum of +2 prefix buffer.
Fixes problem with unexpected node shortenings (in my code at least)
<img width="737" alt="Skjermbilde 2023-08-07 kl  23 42 01" src="https://github.com/zsviczian/excalibrain/assets/125663371/ef8b0c83-72e4-4a50-9499-df294dff5302">

After fix: 
<img width="737" alt="Skjermbilde 2023-08-08 kl  00 05 48" src="https://github.com/zsviczian/excalibrain/assets/125663371/b47fe69d-f4a3-492f-8520-7a534c8f8d4a">


- wrapAt refers proper page.maxLabelLength. (node.ts) Fixes this marginal situation: 
<img width="759" alt="Skjermbilde 2023-08-07 kl  23 37 50" src="https://github.com/zsviczian/excalibrain/assets/125663371/b606e190-c6b9-4b12-a718-f213b0749b9e">

After fix:
<img width="825" alt="Skjermbilde 2023-08-08 kl  00 08 44" src="https://github.com/zsviczian/excalibrain/assets/125663371/fe79205c-3e60-4a9e-88b2-bc120c0079a6">

Also, *0.6 if compactnodes under scene.ts init no longer needed with 2.7 version.